### PR TITLE
Deallocate on panic in ruby

### DIFF
--- a/wasm-thumbnail-rb/lib/wasm/thumbnail/rb.rb
+++ b/wasm-thumbnail-rb/lib/wasm/thumbnail/rb.rb
@@ -39,6 +39,8 @@ module Wasm
                                                                      size,
                                                                      quality)
         rescue RuntimeError
+          # Deallocate
+          wasm_instance.exports.deallocate.call(input_pointer, image_length)
           raise "Error processing the image."
         end
         # Get a pointer to the result
@@ -50,7 +52,7 @@ module Wasm
 
         # Deallocate
         wasm_instance.exports.deallocate.call(input_pointer, image_length)
-        wasm_instance.exports.deallocate.call(output_pointer, bytes.length)
+        wasm_instance.exports.deallocate.call(output_pointer, size)
 
         bytes
       end


### PR DESCRIPTION
Deallocate the already allocated buffer. You can't deallocate the output_pointer b/c it was never allocated due to the exception.