### PR TITLE
Retry resizing until quality is 15

### DIFF
--- a/wasm-thumbnail/src/lib.rs
+++ b/wasm-thumbnail/src/lib.rs
@@ -32,11 +32,21 @@ pub extern "C" fn resize_and_pad(
     let slice: &[u8] = unsafe { std::slice::from_raw_parts(pointer, length) };
 
     let mut out: Vec<u8> = Vec::with_capacity(nsize);
-    // Reserve space at the start for length header
-    out.extend_from_slice(&[0, 0, 0, 0]);
 
-    if let Ok(thumbnail_len) = _resize_and_pad(slice, &mut out, nwidth, nheight, nsize, nquality) {
-        out.splice(..4, thumbnail_len.to_be_bytes().iter().cloned());
+
+
+    let mut mquality = nquality;
+
+    while mquality >= 15 {
+        // Reserve space at the start for length header
+        out.extend_from_slice(&[0, 0, 0, 0]);
+        
+        if let Ok(thumbnail_len) = _resize_and_pad(slice, &mut out, nwidth, nheight, nsize, mquality) {
+            out.splice(..4, thumbnail_len.to_be_bytes().iter().cloned());
+            break;
+        }     
+
+        mquality -= 5;
     }
 
     out.resize(nsize, 0);


### PR DESCRIPTION
The resizer should attempt to fit the resize into the desired size. One way to do this, if the first attempt does not succeed, is to keep trying by lowering the quality until we hit a pre-defined floor of 15. Return the same error as before if even that doesn't work.